### PR TITLE
ci: newer version of coveralls is broken

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -49,7 +49,7 @@ jobs:
         env:
           PLATFORM: ${{ matrix.platform }}
       - name: coveralls
-        run: coveralls
+        run: coveralls debug
         env:
           COVERALLS_PARALLEL: true
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -65,7 +65,7 @@ jobs:
           python -m pip install --upgrade pip
           pip install coveralls==2.1.2
       - name: coveralls
-        run: coveralls --finish
+        run: coveralls debug --finish
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,7 +43,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install tox tox-gh-actions coveralls
+          pip install tox tox-gh-actions coveralls==2.1.2
       - name: Test with tox
         run: tox
         env:
@@ -63,7 +63,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install coveralls
+          pip install coveralls==2.1.2
       - name: coveralls
         run: coveralls --finish
         env:


### PR DESCRIPTION
## Description

coveralls release a new version of their package and it looks like is not compatible with GitHub actions anymore.

## Checklist

- [ ] Tests covering the new functionality have been added
- [ ] Code builds clean without any errors or warnings
- [ ] Documentation has been updated
- [ ] Changes have been added to the `CHANGELOG.md`
- [ ] You added yourself to the `CONTRIBUTORS.md`
